### PR TITLE
Fix responsive header and timer layout (popover + mobile inputs)

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -95,32 +95,32 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <SidebarRail />
       </Sidebar>
       <SidebarInset>
-        <header className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 border-b border-border/60 px-4 py-3 sm:px-6">
-          <div className="flex items-center gap-3">
+        <header className="grid grid-cols-[1fr_auto] grid-rows-[auto_auto] gap-4 border-b border-border/60 px-4 py-3 md:grid-cols-[1fr_auto_1fr] md:grid-rows-[auto] md:items-center md:gap-3 md:px-6">
+          <div className="row-start-1 flex items-center gap-3">
             <SidebarTrigger />
             <Separator orientation="vertical" className="h-5" />
             <div className="flex flex-col">
-              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm lg:text-base">
                 TeacherBuddy
               </p>
-              <h1 className="text-xl font-semibold text-foreground">
+              <h1 className="text-lg font-semibold text-foreground md:text-xl lg:text-2xl xl:text-3xl 2xl:text-3xl">
                 {meta.title}
               </h1>
               {meta.description ? (
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-muted-foreground lg:text-base xl:text-lg 2xl:text-lg">
                   {meta.description}
                 </p>
               ) : null}
             </div>
           </div>
-          <div className="flex justify-center">
+          <div className="row-start-2 col-span-2 flex justify-center md:row-start-1 md:col-span-1 md:justify-center">
             <QuizTimerCard />
           </div>
-          <div className="flex justify-end">
+          <div className="row-start-1 flex justify-end md:col-start-3 md:justify-end">
             <ThemeToggle />
           </div>
         </header>
-        <section className="flex-1 px-4 py-6 sm:px-6 lg:px-8 container mx-auto">
+        <section className="flex-1 px-4 py-6 md:px-6 lg:px-8 container mx-auto">
           {children}
         </section>
       </SidebarInset>

--- a/components/play/quiz-timer-card.tsx
+++ b/components/play/quiz-timer-card.tsx
@@ -12,14 +12,12 @@ import {
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import { useTimer } from '@/hooks/use-timer';
 
 const TICKING_SRC = '/sounds/alarm-clock-ticking.mp3';
@@ -113,9 +111,9 @@ export default function QuizTimerCard() {
   );
 
   return (
-    <div className="flex items-center gap-3">
-      <DropdownMenu>
-        <DropdownMenuTrigger className="flex items-center gap-3 rounded-lg border border-border/60 bg-background/70 px-4 py-2 text-lg font-semibold tabular-nums shadow-xs">
+    <div className="flex flex-wrap items-center gap-2 md:flex-nowrap md:gap-3 lg:gap-4">
+      <Popover>
+        <PopoverTrigger className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/70 px-3 py-2 text-base font-semibold tabular-nums shadow-xs md:w-auto md:justify-start md:px-4 md:text-lg lg:text-xl xl:text-2xl 2xl:text-2xl">
           <span
             className={cn(
               'text-foreground',
@@ -124,70 +122,75 @@ export default function QuizTimerCard() {
             {formattedTime}
           </span>
           <ChevronDownIcon className="size-4 text-muted-foreground" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="center" className="w-96 p-4">
-          <DropdownMenuGroup>
-            <DropdownMenuLabel className="px-0 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        </PopoverTrigger>
+        <PopoverContent
+          align="center"
+          className="w-[min(92vw,24rem)] p-4 md:w-96 lg:w-[26rem] xl:w-[28rem] 2xl:w-[30rem]">
+          <div>
+            <p className="px-0 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm">
               Set timer
-            </DropdownMenuLabel>
-            <div className="mt-3 grid gap-4 sm:grid-cols-3">
+            </p>
+            <div className="mt-3 grid gap-4 md:grid-cols-3">
               <div className="flex flex-col gap-2">
                 <label
                   htmlFor={`${timerId}-hours`}
-                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm">
                   Hours
                 </label>
                 <Input
                   id={`${timerId}-hours`}
                   type="number"
+                  inputMode="numeric"
                   min={0}
                   max={99}
                   value={hours}
                   onChange={(event) => setHours(event.target.value)}
                   placeholder="0"
-                  className="h-9 text-base"
+                  className="h-9 text-base md:text-lg"
                 />
               </div>
               <div className="flex flex-col gap-2">
                 <label
                   htmlFor={`${timerId}-minutes`}
-                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm">
                   Minutes
                 </label>
                 <Input
                   id={`${timerId}-minutes`}
                   type="number"
+                  inputMode="numeric"
                   min={0}
                   max={59}
                   value={minutes}
                   onChange={(event) => setMinutes(event.target.value)}
                   placeholder="0"
-                  className="h-9 text-base"
+                  className="h-9 text-base md:text-lg"
                 />
               </div>
               <div className="flex flex-col gap-2">
                 <label
                   htmlFor={`${timerId}-seconds`}
-                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm">
                   Seconds
                 </label>
                 <Input
                   id={`${timerId}-seconds`}
                   type="number"
+                  inputMode="numeric"
                   min={0}
                   max={59}
                   value={seconds}
                   onChange={(event) => setSeconds(event.target.value)}
                   placeholder="0"
-                  className="h-9 text-base"
+                  className="h-9 text-base md:text-lg"
                 />
               </div>
             </div>
-          </DropdownMenuGroup>
-          <DropdownMenuGroup className="mt-4">
-            <DropdownMenuLabel className="px-0 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          </div>
+          <div className="mt-4">
+            <p className="px-0 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground md:text-sm">
               Volume
-            </DropdownMenuLabel>
+            </p>
             <div className="mt-3 flex items-center gap-3">
               <input
                 type="range"
@@ -198,13 +201,13 @@ export default function QuizTimerCard() {
                 className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-muted accent-foreground"
                 aria-label="Timer volume"
               />
-              <span className="w-8 text-right text-sm tabular-nums text-muted-foreground">
+              <span className="w-8 text-right text-sm tabular-nums text-muted-foreground md:text-base">
                 {Math.round(volume * 100)}%
               </span>
             </div>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </div>
+        </PopoverContent>
+      </Popover>
       <Button
         size="icon-lg"
         variant="ghost"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  className,
+  ...props
+}: PopoverPrimitive.Trigger.Props) {
+  return (
+    <PopoverPrimitive.Trigger
+      data-slot="popover-trigger"
+      className={cn("touch-hitbox cursor-pointer", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverContent, PopoverTrigger }


### PR DESCRIPTION
### Motivation
- Keep the `ThemeToggle` pinned to the top-right on small screens while keeping the timer centered beneath the title area. 
- Improve mobile usability of the timer control by replacing the desktop dropdown with a touch-friendly popover and surfacing numeric keyboards for time inputs. 
- Provide a small, reusable `Popover` wrapper to standardize popover behavior and sizing across the app.

### Description
- Reworked the app header in `components/app-shell.tsx` to use a mobile-first two-row grid and switch to a 3-column `md+` layout so the theme toggle remains top-right and the timer occupies a dedicated mobile row, and adjusted header typography and spacing for `md`/`lg`/`xl`/`2xl` breakpoints. 
- Replaced the `DropdownMenu` usage in `components/play/quiz-timer-card.tsx` with the new `Popover` API and updated trigger/content markup, responsive classes, and popover sizing to use `w-[min(92vw,24rem)]` and larger `md+` widths to avoid overflow. 
- Enabled `inputMode="numeric"` for the hours, minutes, and seconds `Input` fields and adjusted input/text sizes for `md+` breakpoints to surface numeric keyboards on mobile and improve legibility. 
- Added `components/ui/popover.tsx`, a thin wrapper around `@base-ui/react/popover` that provides sane defaults for `Trigger`/`Content`/`Positioner`, shared class names, and consistent animation/positioning utilities.

### Testing
- Attempted to run the development server with `bun --bun next dev -p 3000`, which failed with `Script not found "next"`. 
- No automated unit or integration tests were executed in this change set due to local dev server being unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837bd4a904832fb3885ed2cffd5e3f)