### PR TITLE
Add Sonner toasts for student and quiz actions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -325,3 +325,62 @@
   transform-origin: var(--radix-tooltip-content-transform-origin);
   animation: scaleIn 0.3s ease-in-out;
 }
+
+/* Sonner success/error toast colors (Catppuccin) */
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='error'] {
+  background: oklch(var(--ctp-latte-red)) !important;
+  color: oklch(var(--ctp-latte-crust)) !important;
+  border: 1px solid oklch(var(--ctp-latte-crust)) !important;
+}
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='error']
+  [data-title],
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='error']
+  [data-description] {
+  color: inherit;
+}
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='success'] {
+  background: oklch(var(--ctp-latte-green)) !important;
+  color: oklch(var(--ctp-latte-crust)) !important;
+  border: 1px solid oklch(var(--ctp-latte-crust)) !important;
+}
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='success']
+  [data-title],
+[data-sonner-toaster][data-sonner-theme='light']
+  [data-sonner-toast][data-type='success']
+  [data-description] {
+  color: inherit;
+}
+
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='error'] {
+  background: oklch(var(--ctp-mocha-red)) !important;
+  color: oklch(var(--ctp-mocha-crust)) !important;
+  border: 1px solid oklch(var(--ctp-mocha-crust)) !important;
+}
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='error']
+  [data-title],
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='error']
+  [data-description] {
+  color: inherit;
+}
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='success'] {
+  background: oklch(var(--ctp-mocha-green)) !important;
+  color: oklch(var(--ctp-mocha-crust)) !important;
+  border: 1px solid oklch(var(--ctp-mocha-crust)) !important;
+}
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='success']
+  [data-title],
+[data-sonner-toaster][data-sonner-theme='dark']
+  [data-sonner-toast][data-type='success']
+  [data-description] {
+  color: inherit;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -104,7 +104,7 @@ export default function RootLayout({
           <AppStoreProvider>
             <AppShell footer={<Footer />}>{children}</AppShell>
             <PrivacyNotice />
-            <Toaster />
+            <Toaster closeButton position="bottom-center" />
           </AppStoreProvider>
         </ThemeProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import './globals.css';
 import AppShell from '@/components/app-shell';
 import Footer from '@/components/footer';
 import PrivacyNotice from '@/components/privacy-notice';
+import { Toaster } from '@/components/ui/sonner';
 import { AppStoreProvider } from '@/context/app-store';
 import { ThemeProvider } from '@/context/theme-provider';
 
@@ -103,6 +104,7 @@ export default function RootLayout({
           <AppStoreProvider>
             <AppShell footer={<Footer />}>{children}</AppShell>
             <PrivacyNotice />
+            <Toaster />
           </AppStoreProvider>
         </ThemeProvider>
       </body>

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "teacherbuddy",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "teacherbuddy",
@@ -14,6 +13,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "shadcn": "^3.8.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
       },
@@ -1421,6 +1421,8 @@
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/components/breakout/breakout-groups-card.tsx
+++ b/components/breakout/breakout-groups-card.tsx
@@ -7,6 +7,7 @@ import { formatStudentName } from '@/lib/students';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { CheckIcon, CopyIcon } from 'lucide-react';
+import { toast } from 'sonner';
 
 import GeneratorCardSkeleton from '@/components/loading/generator-card-skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -173,7 +174,10 @@ export default function BreakoutGroupsCard() {
             variant="secondary"
             className="h-9 font-semibold text-base sm:min-w-32"
             disabled={!groups.length}
-            onClick={() => copyAll(groupSummary)}>
+            onClick={async () => {
+              const ok = await copyAll(groupSummary);
+              if (!ok) toast.error('Failed to copy to clipboard.');
+            }}>
             {isAllCopied ? 'Copied!' : 'Copy Groups'}
           </Button>
         </div>
@@ -198,13 +202,17 @@ export default function BreakoutGroupsCard() {
                         ? `Copied group ${index + 1}`
                         : `Copy group ${index + 1}`
                     }
-                    onClick={() => {
+                    onClick={async () => {
                       const names = group
                         .map((student: Student) =>
                           formatStudentName(student.name),
                         )
                         .join(', ');
-                      copyGroup(names);
+                      const ok = await copyGroup(names);
+                      if (!ok) {
+                        toast.error('Failed to copy to clipboard.');
+                        return;
+                      }
                       setCopiedGroupIndex(index);
                       if (copyGroupTimeoutRef.current !== null) {
                         clearTimeout(copyGroupTimeoutRef.current);

--- a/components/quizzes/quiz-editor-form.tsx
+++ b/components/quizzes/quiz-editor-form.tsx
@@ -5,6 +5,7 @@ import type { Question, Quiz } from '@/lib/models';
 import { useMemo, useState } from 'react';
 
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
+import { toast } from 'sonner';
 
 import QuizSelector from '@/components/quizzes/quiz-selector';
 import {
@@ -79,6 +80,9 @@ export default function QuizEditorForm({
     [questions, editingQuestionId],
   );
 
+  /**
+   * Validates quiz metadata, saves changes, and confirms with a toast.
+   */
   const handleSaveQuiz = () => {
     const trimmed = title.trim();
     if (!trimmed) {
@@ -92,12 +96,17 @@ export default function QuizEditorForm({
 
     if (quizId) {
       actions.updateQuiz(quizId, trimmed, questions);
+      toast.success('Quiz updated.');
     } else {
       actions.createQuiz(trimmed, questions);
+      toast.success('Quiz created.');
     }
     setQuizError(null);
   };
 
+  /**
+   * Adds a new question or updates the current edit and resets the inputs.
+   */
   const handleAddOrUpdateQuestion = () => {
     const trimmedPrompt = prompt.trim();
     const trimmedAnswer = answer.trim();
@@ -130,8 +139,16 @@ export default function QuizEditorForm({
     setAnswer('');
     setEditingQuestionId(null);
     setQuestionError(null);
+    toast.success(
+      editingQuestionId ? 'Question updated.' : 'Question added.',
+    );
   };
 
+  /**
+   * Loads the selected question into the edit form.
+   *
+   * @param questionId - Identifier of the question to edit.
+   */
   const handleEditQuestion = (questionId: string) => {
     const question = questions.find((item) => item.id === questionId);
     if (!question) return;
@@ -141,6 +158,11 @@ export default function QuizEditorForm({
     setQuestionError(null);
   };
 
+  /**
+   * Removes a question from the draft and clears the editor if needed.
+   *
+   * @param questionId - Identifier of the question to remove.
+   */
   const handleRemoveQuestion = (questionId: string) => {
     setQuestions((prev) =>
       prev.filter((question) => question.id !== questionId),
@@ -150,8 +172,12 @@ export default function QuizEditorForm({
       setPrompt('');
       setAnswer('');
     }
+    toast.success('Question removed.');
   };
 
+  /**
+   * Cancels question editing and resets the editor fields.
+   */
   const handleCancelEdit = () => {
     setEditingQuestionId(null);
     setPrompt('');
@@ -159,13 +185,20 @@ export default function QuizEditorForm({
     setQuestionError(null);
   };
 
+  /**
+   * Clears the active quiz selection to start a new quiz.
+   */
   const handleNewQuiz = () => {
     actions.selectQuizForEditor(null);
   };
 
+  /**
+   * Deletes the current quiz and confirms the action with a toast.
+   */
   const handleDeleteQuiz = () => {
     if (!quizId) return;
     actions.deleteQuiz(quizId);
+    toast.success('Quiz deleted.');
   };
 
   return (

--- a/components/quizzes/quiz-import-card.tsx
+++ b/components/quizzes/quiz-import-card.tsx
@@ -4,6 +4,8 @@ import type { Question } from '@/lib/models';
 
 import { useState } from 'react';
 
+import { toast } from 'sonner';
+
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -32,6 +34,9 @@ export default function QuizImportCard() {
   const [importError, setImportError] = useState<string | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
 
+  /**
+   * Parses JSON input, creates quizzes, and summarizes the import result.
+   */
   const handleImportQuiz = () => {
     if (!importPayload.trim()) {
       setImportError('Paste a JSON quiz payload to import.');
@@ -86,6 +91,9 @@ export default function QuizImportCard() {
         actions.createQuiz(draft.title, draft.questions),
       );
       setImportNotice(
+        `Imported ${drafts.length} quiz${drafts.length === 1 ? '' : 'zes'}.`,
+      );
+      toast.success(
         `Imported ${drafts.length} quiz${drafts.length === 1 ? '' : 'zes'}.`,
       );
       setImportError(null);

--- a/components/quizzes/quiz-import-card.tsx
+++ b/components/quizzes/quiz-import-card.tsx
@@ -39,6 +39,7 @@ export default function QuizImportCard() {
    */
   const handleImportQuiz = () => {
     if (!importPayload.trim()) {
+      toast.error('Paste a JSON quiz payload to import.');
       setImportError('Paste a JSON quiz payload to import.');
       setImportNotice(null);
       return;
@@ -82,8 +83,10 @@ export default function QuizImportCard() {
         .filter(Boolean) as Array<{ title: string; questions: Question[] }>;
 
       if (!drafts.length) {
-        setImportError('No valid quiz data found in that JSON.');
+        const message = 'No valid quiz data found in that JSON.';
+        setImportError(message);
         setImportNotice(null);
+        toast.error(message);
         return;
       }
 
@@ -99,8 +102,10 @@ export default function QuizImportCard() {
       setImportError(null);
       setImportPayload('');
     } catch {
-      setImportError('Invalid JSON. Please check the format and try again.');
+      const message = 'Invalid JSON. Please check the format and try again.';
+      setImportError(message);
       setImportNotice(null);
+      toast.error(message);
     }
   };
 

--- a/components/students/student-form.tsx
+++ b/components/students/student-form.tsx
@@ -4,6 +4,8 @@ import { normalizeStudentName, studentNameKey } from '@/lib/students';
 
 import { useState } from 'react';
 
+import { toast } from 'sonner';
+
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -47,6 +49,13 @@ export default function StudentForm({
   const [importError, setImportError] = useState<string | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
 
+  /**
+   * Parses a raw comma-separated list, adds unique students, and returns a count.
+   * Uses persisted students to de-dupe against existing roster entries.
+   *
+   * @param raw - Comma-separated student names to add.
+   * @returns The number of new students added to state.
+   */
   const addNames = (raw: string) => {
     const existingKeys = new Set(
       state.persisted.students.map((student) => studentNameKey(student.name)),
@@ -75,6 +84,11 @@ export default function StudentForm({
     return uniqueNames.length;
   };
 
+  /**
+   * Handles manual student entry submission and triggers a toast on success.
+   *
+   * @param event - Form submit event from the student name form.
+   */
   const handleSubmit = (event: FormSubmitEvent) => {
     event.preventDefault();
     const addedCount = addNames(name);
@@ -85,8 +99,17 @@ export default function StudentForm({
     setName('');
     setError(null);
     setImportNotice(null);
+    toast.success(
+      `Added ${addedCount} student${addedCount === 1 ? '' : 's'}.`,
+    );
   };
 
+  /**
+   * Reads a .txt upload, imports students, and confirms the result with a toast.
+   *
+   * @param event - File input change event containing the uploaded file.
+   * @returns A promise that resolves after the file is processed.
+   */
   const handleFileImport = async (event: InputChangeEvent) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -100,6 +123,9 @@ export default function StudentForm({
       } else {
         setImportError(null);
         setImportNotice(
+          `Imported ${addedCount} student${addedCount === 1 ? '' : 's'}.`,
+        );
+        toast.success(
           `Imported ${addedCount} student${addedCount === 1 ? '' : 's'}.`,
         );
       }

--- a/components/students/student-form.tsx
+++ b/components/students/student-form.tsx
@@ -93,15 +93,14 @@ export default function StudentForm({
     event.preventDefault();
     const addedCount = addNames(name);
     if (!addedCount) {
+      toast.error('Enter at least one new student name.');
       setError('Enter at least one new student name.');
       return;
     }
     setName('');
     setError(null);
     setImportNotice(null);
-    toast.success(
-      `Added ${addedCount} student${addedCount === 1 ? '' : 's'}.`,
-    );
+    toast.success(`Added ${addedCount} student${addedCount === 1 ? '' : 's'}.`);
   };
 
   /**
@@ -118,6 +117,7 @@ export default function StudentForm({
       const text = await file.text();
       const addedCount = addNames(text);
       if (!addedCount) {
+        toast.error('No new students were found in that file.');
         setImportError('No new students were found in that file.');
         setImportNotice(null);
       } else {
@@ -131,8 +131,10 @@ export default function StudentForm({
       }
     } catch (error) {
       console.error('Failed to import students', error);
-      setImportError('Could not read the file. Please try again.');
+      const message = 'Could not read the file. Please try again.';
+      setImportError(message);
       setImportNotice(null);
+      toast.error(message);
     } finally {
       event.target.value = '';
     }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner } from 'sonner';
+
+const toastClassNames = {
+  toast:
+    'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+  description: 'group-[.toast]:text-muted-foreground',
+  actionButton:
+    'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+  cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+};
+
+type ToasterProps = ComponentProps<typeof Sonner>;
+
+/**
+ * Renders the global Sonner toast container with theme-aware styling.
+ * Mount once near the app root to enable `toast.*` notifications.
+ *
+ * @param props - Sonner props to customize toast placement and behavior.
+ * @returns The toast container that listens for notification events.
+ */
+export function Toaster({ ...props }: ToasterProps) {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      toastOptions={{ classNames: toastClassNames }}
+      {...props}
+    />
+  );
+}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,38 +1,49 @@
-'use client';
+"use client"
 
-import type { ComponentProps } from 'react';
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 
-import { useTheme } from 'next-themes';
-import { Toaster as Sonner } from 'sonner';
-
-const toastClassNames = {
-  toast:
-    'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-  description: 'group-[.toast]:text-muted-foreground',
-  actionButton:
-    'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-  cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
-};
-
-type ToasterProps = ComponentProps<typeof Sonner>;
-
-/**
- * Renders the global Sonner toast container with theme-aware styling.
- * Mount once near the app root to enable `toast.*` notifications.
- *
- * @param props - Sonner props to customize toast placement and behavior.
- * @returns The toast container that listens for notification events.
- */
-export function Toaster({ ...props }: ToasterProps) {
-  const { theme = 'system' } = useTheme();
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme={theme as ToasterProps["theme"]}
       className="toaster group"
-      richColors
-      toastOptions={{ classNames: toastClassNames }}
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
       {...props}
     />
-  );
+  )
 }
+
+export { Toaster }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -30,6 +30,7 @@ export function Toaster({ ...props }: ToasterProps) {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      richColors
       toastOptions={{ classNames: toastClassNames }}
       {...props}
     />

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "shadcn": "^3.8.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0"
   },


### PR DESCRIPTION
### Motivation

- Provide immediate user feedback for roster and quiz operations by adding toast notifications and a centralized toast container.

### Description

- Add the `sonner` dependency and a theme-aware global `Toaster` at `components/ui/sonner.tsx`, and mount it in the app root via `app/layout.tsx` with `<Toaster />`.
- Wire `toast.success(...)` notifications into student flows in `components/students/student-form.tsx` (add/import) and `components/students/student-table.tsx` (edit/toggle/delete/clear) and add small helper handlers and JSDoc comments for clarity.
- Wire `toast.success(...)` notifications into quiz workflows in `components/quizzes/quiz-editor-form.tsx` (create/update/delete quizzes and questions) and `components/quizzes/quiz-import-card.tsx` (import), and add brief JSDoc comments where appropriate.

### Testing

- Ran `bun add sonner` to install `sonner@2.0.7`, which completed successfully. (succeeded)
- Started the dev server with `bun --bun next dev`, and Next reported the app ready at `http://localhost:3000`. (succeeded)
- Attempted an automated Playwright smoke check to add a student and capture a screenshot, but Playwright failed to launch Chromium in the container (SIGSEGV), so the UI interaction check could not complete. (failed)
- No unit test suite was executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986337217e8832f8a239723622c4ef0)